### PR TITLE
fix for titles and sipler "tattFra" section

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,23 +14,21 @@ import HeaderLink from "./HeaderLink.astro";
       </HeaderLink>
       <HeaderLink href="/search" aria-label="Søk">
         <span class="flex items-center">
-          <span class="inline-flex">
+          <span class="flex items-center gap-1">
             Søk
-            <span class="ml-1 inline-flex items-center">
-              <svg
-                width="32"
-                height="32"
-                viewBox="0 0 15 15"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 6.5C10 8.433 8.433 10 6.5 10C4.567 10 3 8.433 3 6.5C3 4.567 4.567 3 6.5 3C8.433 3 10 4.567 10 6.5ZM9.30884 10.0159C8.53901 10.6318 7.56251 11 6.5 11C4.01472 11 2 8.98528 2 6.5C2 4.01472 4.01472 2 6.5 2C8.98528 2 11 4.01472 11 6.5C11 7.56251 10.6318 8.53901 10.0159 9.30884L12.8536 12.1464C13.0488 12.3417 13.0488 12.6583 12.8536 12.8536C12.6583 13.0488 12.3417 13.0488 12.1464 12.8536L9.30884 10.0159Z"
-                  fill="currentColor"
-                  fill-rule="evenodd"
-                  clip-rule="evenodd"></path>
-              </svg>
-            </span>
+            <svg
+              width="32"
+              height="32"
+              viewBox="0 0 15 15"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M10 6.5C10 8.433 8.433 10 6.5 10C4.567 10 3 8.433 3 6.5C3 4.567 4.567 3 6.5 3C8.433 3 10 4.567 10 6.5ZM9.30884 10.0159C8.53901 10.6318 7.56251 11 6.5 11C4.01472 11 2 8.98528 2 6.5C2 4.01472 4.01472 2 6.5 2C8.98528 2 11 4.01472 11 6.5C11 7.56251 10.6318 8.53901 10.0159 9.30884L12.8536 12.1464C13.0488 12.3417 13.0488 12.6583 12.8536 12.8536C12.6583 13.0488 12.3417 13.0488 12.1464 12.8536L9.30884 10.0159Z"
+                fill="currentColor"
+                fill-rule="evenodd"
+                clip-rule="evenodd"></path>
+            </svg>
           </span>
         </span>
       </HeaderLink>

--- a/src/layouts/RecipePost.astro
+++ b/src/layouts/RecipePost.astro
@@ -17,18 +17,19 @@ const { title, tags, ingredienser, images, tattFra, seo_image } = Astro.props;
   {seo_image}
 >
   <section
-    class="prose prose-lg mx-auto px-2 py-4 leading-6 lg:prose-xl lg:leading-6"
+    class="prose mx-auto py-4 leading-6 lg:prose-lg xl:prose-xl lg:leading-6"
   >
     {
       tattFra && (
-        <p class="rounded bg-gray-300 p-2 sm:w-5/6 md:w-2/3">
+        <p class="w-fit rounded bg-gray-300 p-2">
           <span class="font-bold">NB! </span>Denne oppskriften er fra eller
           basert på denne:
-          <span>
-            <a href={tattFra} class="font-bold underline underline-offset-1">
-              {tattFra}
-            </a>
-          </span>
+          <a
+            href={tattFra}
+            class="block break-all font-bold underline underline-offset-1"
+          >
+            {tattFra}
+          </a>
         </p>
       )
     }


### PR DESCRIPTION
The `tattFra:` will always show link on the next line:
![image](https://github.com/user-attachments/assets/64f8ff49-ee50-4580-b01d-2f696e30e163)


Titles should no longer grow to the point the navbar and other elements shrink

example 1:
![image](https://github.com/user-attachments/assets/014cb2e7-ef3d-46e1-8395-232cd870f7fb)

example 2:
![image](https://github.com/user-attachments/assets/0aab339d-3c1a-433b-ba89-b6188fd7f6da)
